### PR TITLE
unrequired :article in controller

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -79,7 +79,7 @@ class ArticlesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def article_params
-      params.require(:article).permit(
+      params.permit(
         :title,
         :slug,
         :content,


### PR DESCRIPTION
Using cli-uploader, I was unable to #create an article because I was missing the :article param. 