### PR TITLE
Hotfix: rename type to media_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -692,5 +692,8 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
 
+RUBY VERSION
+   ruby 2.4.2p198
+
 BUNDLED WITH
    1.16.0

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -65,7 +65,7 @@ class MediaController < ApplicationController
         :title,
         :caption,
         :is_featured,
-        :type,
+        :media_type,
         :attachment
       )
     end

--- a/db/migrate/20171119060337_rename_media_type.rb
+++ b/db/migrate/20171119060337_rename_media_type.rb
@@ -1,0 +1,5 @@
+class RenameMediaType < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :media, :type, :media_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109210835) do
+ActiveRecord::Schema.define(version: 20171119060337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20171109210835) do
     t.string "title"
     t.text "caption"
     t.boolean "is_featured"
-    t.string "type"
+    t.string "media_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"


### PR DESCRIPTION
Fix #49 by renaming `type` column.