### PR TITLE
reversed article media order; fixes #97

### DIFF
--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -12,16 +12,15 @@ Types::ArticleType = GraphQL::ObjectType.define do
   field :section, !Types::SectionType
   field :comments, types[!Types::CommentType]
   field :contributors, types[!Types::UserType]
-  field :media, types[!Types::MediumType]
   field :outquotes, types[Types::OutquoteType]
 
   # We want media shown in the order they were uploaded, which is by
   # reverse id.
-  # field :media, types[!Types::MediumType] do
-  #   resolve -> (obj, args, ctx) {
-  #     obj.media.reverse
-  #   }
-  # end
+  field :media, types[!Types::MediumType] do
+    resolve -> (obj, args, ctx) {
+      obj.media.reverse
+    }
+  end
 
   field :published_comments, types[!Types::CommentType] do
     resolve -> (obj, args, ctx) {

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -12,15 +12,16 @@ Types::ArticleType = GraphQL::ObjectType.define do
   field :section, !Types::SectionType
   field :comments, types[!Types::CommentType]
   field :contributors, types[!Types::UserType]
+  field :media, types[!Types::MediumType]
   field :outquotes, types[Types::OutquoteType]
 
   # We want media shown in the order they were uploaded, which is by
   # reverse id.
-  field :media, types[!Types::MediumType] do
-    resolve -> (obj, args, ctx) {
-      obj.media.reverse
-    }
-  end
+  # field :media, types[!Types::MediumType] do
+  #   resolve -> (obj, args, ctx) {
+  #     obj.media.reverse
+  #   }
+  # end
 
   field :published_comments, types[!Types::CommentType] do
     resolve -> (obj, args, ctx) {

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -12,8 +12,15 @@ Types::ArticleType = GraphQL::ObjectType.define do
   field :section, !Types::SectionType
   field :comments, types[!Types::CommentType]
   field :contributors, types[!Types::UserType]
-  field :media, types[Types::MediumType]
   field :outquotes, types[Types::OutquoteType]
+
+  # We want media shown in the order they were uploaded, which is by
+  # reverse id.
+  field :media, types[!Types::MediumType] do
+    resolve -> (obj, args, ctx) {
+      obj.media.reverse
+    }
+  end
 
   field :published_comments, types[!Types::CommentType] do
     resolve -> (obj, args, ctx) {
@@ -21,6 +28,8 @@ Types::ArticleType = GraphQL::ObjectType.define do
     }
   end
 
+  # created_at must be in this specific format for it to be readable, as a
+  # timestamp, across all browsers.
   field :created_at, types.String do
     resolve -> (obj, args, ctx) {
       obj.created_at.strftime('%Y/%m/%d %H:%M:%S %z')


### PR DESCRIPTION
GraphQL feeds us media in descending order of ID, which is the exact opposite order in which the uploader uploaded the media in. This PR modifies `MediumType` field `media` on `ArticleType` to reverse the order of media. 

Fixes #97.