### PR TITLE
remove bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,3 @@ gem 'rack-throttle'
 gem 'pg_search'
 gem 'seed_dump'
 gem 'graphql'
-
-group :development, :production do
-  gem 'bootsnap', require: false
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -565,8 +565,6 @@ GEM
     aws-sigv2 (1.0.1)
     aws-sigv4 (1.0.2)
     bcrypt (3.1.11)
-    bootsnap (1.1.7)
-      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (9.1.0)
     climate_control (0.2.0)
@@ -623,7 +621,6 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    msgpack (1.2.0)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -771,7 +768,6 @@ PLATFORMS
 DEPENDENCIES
   airborne
   aws-sdk
-  bootsnap
   byebug
   devise_token_auth
   dotenv-rails
@@ -799,4 +795,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup'
+


### PR DESCRIPTION
I've been encountering warnings after starting Emacs ever since I installed RVM. They look like this:
```
Ignoring {gem}-{version} because its extensions are not built.  Try: gem pristine bcrypt --version {version}
```

I reinstalled RVM and, although the warning went away, my Rails broke. Running `rails server` gave me the same error as the OP in bkeepers/dotenv#321. Many participants in the discussion (and other issues I've researched have had the same problem with bootsnap. The recommended and upvoted solutions have consistently been: remove `require "bootsnap/setup"` from `boot.rb` (essentially removing bootsnap from the setup).

**The line change removed the error.** There is an ongoing debate around this in Shopify/bootsnap#134 (around 12 days old) but, for now, _I strongly suggest we remove bootsnap_.

A bootsnap issue has also broken the Rails console on our Elastic Beanstalk environment. The image below is a screenshot from Jason Lin's latest attempt:
![image](https://user-images.githubusercontent.com/15334952/36946537-451e3da6-1f8c-11e8-9591-cd6e7c60b268.png)

`sudo` does not apply here—it is a permission issue within bootsnap. I risked an `eb deploy` on this branch and the Rails console worked again.

In summary, we should remove bootsnap until the above issue is resolved and a fix is merged.