### PR TITLE
properly ordered media in reverse

### DIFF
--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -8,19 +8,11 @@ Types::ArticleType = GraphQL::ObjectType.define do
   field :preview, types.String
   field :volume, !types.Int
   field :issue, !types.Int
-  field :rank, types.Int
   field :section, !Types::SectionType
   field :comments, types[!Types::CommentType]
   field :contributors, types[!Types::UserType]
-  field :outquotes, types[Types::OutquoteType]
-
-  # We want media shown in the order they were uploaded, which is by
-  # reverse id.
-  field :media, types[!Types::MediumType] do
-    resolve -> (obj, args, ctx) {
-      obj.media.reverse
-    }
-  end
+  field :outquotes, types[Types::OutquoteType]  
+  field :media, types[!Types::MediumType]
 
   field :published_comments, types[!Types::CommentType] do
     resolve -> (obj, args, ctx) {

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -15,9 +15,12 @@ class Article < ApplicationRecord
            through: :authorships,
            dependent: :destroy,
            source: :user
-  has_many :media, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :outquotes, dependent: :destroy
+
+  # We want media shown in the order they were uploaded, which is by
+  # order of ascending created_at.
+  has_many :media, -> { order(created_at: :asc) }, dependent: :destroy
 
   def self.order_by_rank
     Article


### PR DESCRIPTION
We reverse the media order for an article so they show in the order they were uploaded in, which is by
ascending order of `created_at`. We did this by overriding the `:media` field on GraphQL `ArticleType`'s fields, but this only reverses media for media we get through GraphQL. The featured article, for instance, has media that is gotten through a regular `read_attribute` behind the scenes and has media that is not reversed in order when it is received on the client.

This PR changes the relationship the article class has with the media class to make sure every time an article gets its associated media, it is ordered by `created_at` (ascending).